### PR TITLE
Remove 1/Ts from raised-cosine calculation

### DIFF
--- a/content/pulse_shaping.rst
+++ b/content/pulse_shaping.rst
@@ -194,7 +194,7 @@ We will create a raised-cosine filter using a :math:`\beta` of 0.35, and we will
     beta = 0.35
     Ts = sps # Assume sample rate is 1 Hz, so sample period is 1, so *symbol* period is 8
     t = np.arange(num_taps) - (num_taps-1)//2
-    h = 1/Ts*np.sinc(t/Ts) * np.cos(np.pi*beta*t/Ts) / (1 - (2*beta*t/Ts)**2)
+    h = np.sinc(t/Ts) * np.cos(np.pi*beta*t/Ts) / (1 - (2*beta*t/Ts)**2)
     plt.figure(1)
     plt.plot(t, h, '.')
     plt.grid(True)


### PR DESCRIPTION
I was running this example and plotting the result of h returned an impulse response that peaked at 0.12. This does not match with provided graph and it produces the wrong result for the convolution step.

Removing the scalar of 1/Ts for the sinc function seems to produce the correct result.

Disclaimer: This is not my field of expertise and study this for fun. I very well could be wrong.