### PR TITLE
Enable Python API in cmake

### DIFF
--- a/content/usrp.rst
+++ b/content/usrp.rst
@@ -45,7 +45,7 @@ The terminal commands below should build and install the latest version of UHD, 
  cd uhd/host
  mkdir build
  cd build
- cmake -DENABLE_TESTS=OFF -DENABLE_C_API=OFF -DENABLE_MANUAL=OFF ..
+ cmake -DENABLE_TESTS=OFF -DENABLE_C_API=OFF -DENABLE_PYTHON_API=ON -DENABLE_MANUAL=OFF ..
  make -j8
  sudo make install
  sudo ldconfig


### PR DESCRIPTION
The python guide is missing the cmake flag to enable python API while building UHD.