### PR TITLE
Update hyperlink name for PyQt Chapter

### DIFF
--- a/content/pyqt.rst
+++ b/content/pyqt.rst
@@ -1,4 +1,4 @@
-.. _freq-domain-chapter:
+.. _pyqt-chapter:
 
 ##########################
 Real-Time GUIs with PyQt


### PR DESCRIPTION
The PyQt chapter uses the same hyperlink name as the Frequency Domain chapter, resulting in invalid links being generated.

There does not appear to be any references to the PyQt chapter and hence no links will break while all hyperlinks to the Frequency Domain chapter should now be fixed.