### PR TITLE
Replace `nyq` argument with `fs` in firwin calls

### DIFF
--- a/content-es/filters.rst
+++ b/content-es/filters.rst
@@ -225,7 +225,7 @@ Y aunque todavía no hemos entrado en el diseño del filtro, aquí está el cód
     sample_rate = 32000 # Hz
 
     # create our low pass filter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # plot the impulse response
     plt.plot(h, '.-')

--- a/content-fr/filters.rst
+++ b/content-fr/filters.rst
@@ -162,7 +162,7 @@ Et même si nous n'avons pas encore abordé la conception des filtres, voici le 
     sample_rate = 32000 # Hz
 
     # créer notre filtre passe-bas
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # tracer la réponse impulsionnelle
     plt.plot(h, '.-')

--- a/content-nl/filters.rst
+++ b/content-nl/filters.rst
@@ -221,7 +221,7 @@ Ook al hebben we nog niets geleerd over filterontwerp, hieronder kun je de code 
     sample_rate = 32000 # Hz
 
     # laag-doorlaatfilter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # impulsrespons weergeven
     plt.plot(h, '.-')

--- a/content-ukraine/filters.rst
+++ b/content-ukraine/filters.rst
@@ -231,7 +231,7 @@ Example Use-Case
     sample_rate = 32000 # Hz
 
     # create our low pass filter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # plot the impulse response
     plt.plot(h, '.-')

--- a/content-zh/filters.rst
+++ b/content-zh/filters.rst
@@ -226,7 +226,7 @@ Example Use-Case
     sample_rate = 32000 # Hz
 
     # create our low pass filter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # plot the impulse response
     plt.plot(h, '.-')

--- a/content/filters.rst
+++ b/content/filters.rst
@@ -225,7 +225,7 @@ And even though we haven't gotten into filter design yet, here is the Python cod
     sample_rate = 32000 # Hz
 
     # create our low pass filter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate/2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # plot the impulse response
     plt.plot(h, '.-')

--- a/figure-generating-scripts/filters_chapter.py
+++ b/figure-generating-scripts/filters_chapter.py
@@ -8,7 +8,7 @@ if False:
     sample_rate = 32000  # Hz
 
     # create our low pass filter
-    h = signal.firwin(num_taps, cut_off, nyq=sample_rate / 2)
+    h = signal.firwin(num_taps, cut_off, fs=sample_rate)
 
     # plot the impulse response
     plt.plot(h, '.-')


### PR DESCRIPTION
The Nyquist frequency (`nyq`) argument has been deprecated since Scipy version 1.0.0 and removed in version 1.12.0. Sampling frequency (`fs`) should be provided instead.

P.S. would you prefer if these minor fixes are done in a single big PR or it is fine to submit them one by one as I bump into any issues?