### PR TITLE
Avoid redefining Python built-in types

### DIFF
--- a/content-es/rds.rst
+++ b/content-es/rds.rst
@@ -412,7 +412,7 @@ Tenga en cuenta que **no** necesita revisar todo este código, ni nada de él, e
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -420,13 +420,13 @@ Tenga en cuenta que **no** necesita revisar todo este código, ni nada de él, e
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -550,11 +550,11 @@ Para aquellos que quieran aprender cómo funciona este código, les proporcionar
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0
@@ -826,7 +826,7 @@ Resumen y código final
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -834,13 +834,13 @@ Resumen y código final
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -915,11 +915,11 @@ Resumen y código final
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0

--- a/content-fr/rds.rst
+++ b/content-fr/rds.rst
@@ -426,7 +426,7 @@ Notez que vous n'avez **pas** besoin de parcourir tout ce code, ou une partie de
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 octets remplis de 0
+                 group = bytearray(8) # 8 octets remplis de 0
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -434,13 +434,13 @@ Notez que vous n'avez **pas** besoin de parcourir tout ce code, ou une partie de
                      # octets de données brutes, tels que reçus du RDS. 8 octets d'information, suivis de 4 caractères de décalage RDS : ABCD/ABcD/EEEE (aux Etats-Unis) que nous laissons de côté ici.
                      # Mots d'information RDS
                      # le numéro de bloc est soit 0,1,2,3 donc c'est comme ça qu'on remplit les 8 octets
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # liste de listes d'octets de longueur 8
+                     #print(group)
+                     bytes_out.append(group) # liste de listes d'octets de longueur 8
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -564,11 +564,11 @@ Pour ceux qui veulent apprendre comment ce code fonctionne, je vais fournir quel
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # voici ce que chacun signifie, par exemple RT est radiotexte qui est le seul que nous décodons ici : ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b si 1, a si 0
@@ -841,7 +841,7 @@ Vous l'avez fait! Ci-dessous se trouve tout le code ci-dessus, concaténé, il d
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 octets remplis de 0
+                 group = bytearray(8) # 8 octets remplis de 0
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -849,13 +849,13 @@ Vous l'avez fait! Ci-dessous se trouve tout le code ci-dessus, concaténé, il d
                      # octets de données brutes, tels que reçus du RDS. 8 octets d'information, suivis de 4 caractères de décalage RDS : ABCD/ABcD/EEEE (aux Etats-Unis) que nous laissons de côté ici.
                      # Mots d'information RDS
                      # le numéro de bloc est soit 0,1,2,3 donc c'est comme ça qu'on remplit les 8 octets
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # liste de listes d'octets de longueur 8
+                     #print(group)
+                     bytes_out.append(group) # liste de listes d'octets de longueur 8
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -930,11 +930,11 @@ Vous l'avez fait! Ci-dessous se trouve tout le code ci-dessus, concaténé, il d
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # voici ce que chacun signifie, par exemple RT est radiotexte qui est le seul que nous décodons ici : ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b si 1, a si 0

--- a/content-nl/rds.rst
+++ b/content-nl/rds.rst
@@ -489,7 +489,7 @@ Het heeft een vrij makkelijke functie maar lost het complex op.
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -497,13 +497,13 @@ Het heeft een vrij makkelijke functie maar lost het complex op.
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -631,11 +631,11 @@ Andere mogelijke berichttypes zijn ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC",
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0
@@ -922,7 +922,7 @@ Mocht je de code moeten tweaken om het werkend te krijgen met jouw opname of SDR
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -930,13 +930,13 @@ Mocht je de code moeten tweaken om het werkend te krijgen met jouw opname of SDR
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -1011,11 +1011,11 @@ Mocht je de code moeten tweaken om het werkend te krijgen met jouw opname of SDR
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0

--- a/content-ukraine/rds.rst
+++ b/content-ukraine/rds.rst
@@ -412,7 +412,7 @@ Note, you **do not** need to go through all of this code, or any of it, especial
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -420,13 +420,13 @@ Note, you **do not** need to go through all of this code, or any of it, especial
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -550,11 +550,11 @@ For those who want to learn how this code works, I'll provide some added informa
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0
@@ -826,7 +826,7 @@ You did it!  Below is all of the code above, concatenated, it should work with t
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -834,13 +834,13 @@ You did it!  Below is all of the code above, concatenated, it should work with t
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -915,11 +915,11 @@ You did it!  Below is all of the code above, concatenated, it should work with t
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0

--- a/content/rds.rst
+++ b/content/rds.rst
@@ -412,7 +412,7 @@ Note, you **do not** need to go through all of this code, or any of it, especial
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -420,13 +420,13 @@ Note, you **do not** need to go through all of this code, or any of it, especial
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -550,11 +550,11 @@ For those who want to learn how this code works, I'll provide some added informa
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0
@@ -826,7 +826,7 @@ You did it!  Below is all of the code above, concatenated, it should work with t
              if block_number == 0 and good_block:
                  group_assembly_started = True
                  group_good_blocks_counter = 1
-                 bytes = bytearray(8) # 8 bytes filled with 0s
+                 group = bytearray(8) # 8 bytes filled with 0s
              if group_assembly_started:
                  if not good_block:
                      group_assembly_started = False
@@ -834,13 +834,13 @@ You did it!  Below is all of the code above, concatenated, it should work with t
                      # raw data bytes, as received from RDS. 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US) which we leave out here
                      # RDS information words
                      # block_number is either 0,1,2,3 so this is how we fill out the 8 bytes
-                     bytes[block_number*2] = (dataword >> 8) & 255
-                     bytes[block_number*2+1] = dataword & 255
+                     group[block_number*2] = (dataword >> 8) & 255
+                     group[block_number*2+1] = dataword & 255
                      group_good_blocks_counter += 1
                      #print('group_good_blocks_counter:', group_good_blocks_counter)
                  if group_good_blocks_counter == 5:
-                     #print(bytes)
-                     bytes_out.append(bytes) # list of len-8 lists of bytes
+                     #print(group)
+                     bytes_out.append(group) # list of len-8 lists of bytes
              block_bit_counter = 0
              block_number = (block_number + 1) % 4
              blocks_counter += 1
@@ -915,11 +915,11 @@ You did it!  Below is all of the code above, concatenated, it should work with t
  radiotext_AB_flag = 0
  radiotext = [' ']*65
  first_time = True
- for bytes in bytes_out:
-     group_0 = bytes[1] | (bytes[0] << 8)
-     group_1 = bytes[3] | (bytes[2] << 8)
-     group_2 = bytes[5] | (bytes[4] << 8)
-     group_3 = bytes[7] | (bytes[6] << 8)
+ for group in bytes_out:
+     group_0 = group[1] | (group[0] << 8)
+     group_1 = group[3] | (group[2] << 8)
+     group_2 = group[5] | (group[4] << 8)
+     group_3 = group[7] | (group[6] << 8)
       
      group_type = (group_1 >> 12) & 0xf # here is what each one means, e.g. RT is radiotext which is the only one we decode here: ["BASIC", "PIN/SL", "RT", "AID", "CT", "TDC", "IH", "RP", "TMC", "EWS", "___", "___", "___", "___", "EON", "___"]
      AB = (group_1 >> 11 ) & 0x1 # b if 1, a if 0


### PR DESCRIPTION
Since `bytes` is a built-in class in Python, it is better to avoid redefining it as a variable, especially when dealing with raw bytes.