### PR TITLE
Remove int(mu) in timing synchronization input

### DIFF
--- a/content/sync.rst
+++ b/content/sync.rst
@@ -145,7 +145,7 @@ The following Python code implements the Mueller and Muller clock recovery techn
     i_in = 0 # input samples index
     i_out = 2 # output index (let first two outputs be 0)
     while i_out < len(samples) and i_in+16 < len(samples):
-        out[i_out] = samples[i_in + int(mu)] # grab what we think is the "best" sample
+        out[i_out] = samples[i_in] # grab what we think is the "best" sample
         out_rail[i_out] = int(np.real(out[i_out]) > 0) + 1j*int(np.imag(out[i_out]) > 0)
         x = (out_rail[i_out] - out_rail[i_out-2]) * np.conj(out[i_out-1])
         y = (out[i_out] - out[i_out-2]) * np.conj(out_rail[i_out-1])


### PR DESCRIPTION
Line148: adding int(mu) does nothing since mu is always fractional at this point (0 <= mu < 1). Taking int(fractional number) always returns 0