### PR TITLE
Update homepage.html with the new version of potik embed for cw-plus-noise

### DIFF
--- a/_templates/homepage.html
+++ b/_templates/homepage.html
@@ -34,61 +34,14 @@
 </h4>
 
 <!-- ════════ POTIK INTERACTIVE LAB EMBED ════════ -->
-<div style="
-  margin: 18px auto 26px;
-  border: 1px solid #dcdcdc;
-  border-radius: 7px;
-  background: #ffffff;
-  box-shadow: 0 1px 3px rgba(0,0,0,.05), 0 6px 22px -16px rgba(0,0,0,.25);
-  overflow: hidden;
-  width: 90%;
-">
-  <div style="
-    position: relative;
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    min-height: 460px;
-  ">
-    <iframe
-      src="https://embed.potik.org/cw-plus-noise?theme=pysdr&viewmode=minimal"
-      title="Tone + Gaussian noise — interactive lab (Potik)"
-      loading="lazy"
-      allow="fullscreen"
-      sandbox="allow-scripts allow-same-origin"
-      style="position:absolute; inset:0; width:100%; height:100%; border:0; display:block;"
-    ></iframe>
-  </div>
-  <div style="
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 7px 13px;
-    background: #fafafa;
-    border-top: 1px solid #ededed;
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 10.5px;
-    color: #8a8576;
-    letter-spacing: .2px;
-  ">
-    <span>
-      <b style="color:#3f6f4a; font-weight:600;">cw_src</b>
-      <span style="color:#c4bfb0; margin:0 6px;">▸</span>
-      <span style="color:#5a564a;">+ noise</span>
-      <span style="color:#c4bfb0; margin:0 6px;">▸</span>
-      <span style="color:#5a564a;">spectrum</span>
-      <span style="color:#c4bfb0; margin:0 6px;">·</span>
-      <span style="color:#5a564a;">scope</span>
-    </span>
-    <span style="display:inline-flex; align-items:center; gap:14px;">
-      <a href="https://potik.app" target="_blank" rel="noopener" title="Built with Potik"
-         style="display:inline-flex; align-items:center; gap:5px; color:#5a564a; text-decoration:none; font-family:'JetBrains Mono', ui-monospace, monospace; font-size:10.5px;">
-        <img src="https://pysdr.org/_static/potik-icon.svg" alt="" width="13" height="13" style="display:block; opacity:.85;"/>
-        <span>Powered by <b style="color:#2c6bb3; font-weight:600;">Пotik</b></span>
-      </a>
-      <a href="https://embed.potik.org/cw-plus-noise?theme=pysdr" target="_blank" rel="noopener" style="color:#2c6bb3; text-decoration:none;">Open standalone ↗</a>
-    </span>
-  </div>
-</div>
+<iframe
+          src="https://embed.potik.org/cw-plus-noise?theme=pysdr&viewmode=minimal"
+          title="Tone + Gaussian noise — interactive lab (Potik · local)"
+          loading="lazy"
+          allow="fullscreen"
+          sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+          style="display:block; width:100%; aspect-ratio:16/9; min-height:460px; border:0; margin:18px 0 26px;"
+        ></iframe>
 <!-- ════════ /POTIK EMBED ════════ -->
 
 <br />


### PR DESCRIPTION
now, potik's embeds are noisy with a bunch of divs and other html - this was an initial miss of my design. this fixes it, with clean iframe with all the main params inside iframe. links inside the iframe are allowed to open new tab - tested on other domain. 